### PR TITLE
Fix urllib3 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ numpy
 dash
 dash-bootstrap-components
 pyeloverblik
-urllib3==1.25.11
+urllib3>=1.26


### PR DESCRIPTION
## Summary
- unpin urllib3 requirement and allow newer versions
- reinstall dependencies

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import requests
print(requests.__version__)
print(requests.get('https://example.com').status_code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68448c0fd7f08324bcb573a8e6b73d99