### PR TITLE
Add PV production simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # eloverblik-solceller
 Estimering af solcelle business case ud fra eloverblik data
 
+Nu kan applikationen også estimere solcelleproduktion for en valgfri adresse i Danmark ved hjælp af data fra EU's PVGIS tjeneste.
+
 ## Docker
 
 Byg og kør applikationen i en Docker container:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ dash-bootstrap-components
 pyeloverblik
 urllib3>=1.26
 requests
+geopy


### PR DESCRIPTION
## Summary
- support geocoding with geopy and PVGIS calls
- add UI elements for address and simulation
- implement `simulate_pv_production` function
- document the new ability in README

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m py_compile app.py functions.py`
- `python3 - <<'PY'
from functions import simulate_pv_production
simulate_pv_production('Gothersgade 1, København', '2020-06-01', '2020-06-10', 5, 'Syd')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6844938c5e14832498dc6a48198dc2b2