### PR TITLE
Fix PVGIS API year range

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Estimering af solcelle business case ud fra eloverblik data
 
 Nu kan applikationen også estimere solcelleproduktion for en valgfri adresse i Danmark ved hjælp af data fra EU's PVGIS tjeneste.
+Perioden for solcellevejret vælges nu med en separat datovælger i brugerfladen.
 
 ## Docker
 

--- a/app.py
+++ b/app.py
@@ -134,6 +134,14 @@ app.layout = dbc.Container([
             html.Br(),
             html.Div(id="pv-config-summary"),
             html.Br(),
+            html.H6("Periode for solcellevejr"),
+            dcc.DatePickerRange(
+                id='pv-date-picker-range',
+                start_date=datetime.now()-timedelta(days=30),
+                end_date=datetime.now(),
+                display_format="YYYY-MM-DD"
+            ),
+            html.Br(),
             dbc.Button("Simulér produktion",
                        id="simulate-pv-button", n_clicks=0, color="primary"),
             html.Br(),
@@ -292,8 +300,8 @@ def save_pv_configuration(n_clicks, pv_size, orientation, battery_size):
     State('input-address', 'value'),
     State('input-pv-size', 'value'),
     State('dropdown-orientation', 'value'),
-    State('date-picker-range', 'start_date'),
-    State('date-picker-range', 'end_date'),
+    State('pv-date-picker-range', 'start_date'),
+    State('pv-date-picker-range', 'end_date'),
     prevent_initial_call=True
 )
 def simulate_pv(n_clicks, address, pv_size, orientation, start_date, end_date):

--- a/functions.py
+++ b/functions.py
@@ -169,6 +169,9 @@ def simulate_pv_production(address, start_date, end_date, pv_size_kw, orientatio
 
     start_year = pd.to_datetime(start_date).year
     end_year = pd.to_datetime(end_date).year
+    # Clamp years to the range allowed by PVGIS (2005-2020)
+    start_year = min(max(start_year, 2005), 2020)
+    end_year = min(max(end_year, 2005), 2020)
 
     url = (
         "https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?"


### PR DESCRIPTION
## Summary
- clamp PVGIS API startyear and endyear parameters to supported range
- add separate date range picker for PV simulation

## Testing
- `pytest -q`
- `python -m py_compile app.py functions.py`


------
https://chatgpt.com/codex/tasks/task_e_684495e9c43c8324afc574b289ccf555