### PR TITLE
Add DMI cache worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ docker build -t eloverblik .
 # Kør containeren på port 8050
 docker run -p 8050:8050 eloverblik
 ```
+
+### DMI cache
+
+Set `DMI_START_CACHE_DATE` to the first date (YYYY-MM-DD) you wish to
+cache weather observations from the DMI API. Optionally configure
+`DMI_API_KEY` and `DMI_API_URL` if needed. The application will check
+the cache every hour and download missing days automatically.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from functions import *
+from dmi_cache import start_dmi_cache_worker
 from datetime import datetime, timedelta
 import dash
 from dash import html, dcc, Input, Output, State
@@ -374,4 +375,5 @@ def simulate_pv(n_clicks, address, pv_size, orientation, start_date, end_date):
 #     if (n_clicks is not None) or (n_clicks is not N_CLICKS):
 #         # Here, you can includ
 if __name__ == '__main__':
+    start_dmi_cache_worker()
     app.run(debug=False, host='0.0.0.0', port=8050)

--- a/dmi_cache.py
+++ b/dmi_cache.py
@@ -1,0 +1,79 @@
+import os
+import json
+import time
+from datetime import datetime, timedelta
+from threading import Thread
+from typing import Optional
+
+import requests
+
+DMI_CACHE_DIR = os.environ.get("DMI_CACHE_DIR", "dmi_cache")
+DMI_START_CACHE_DATE = os.environ.get("DMI_START_CACHE_DATE")
+DMI_API_URL = os.environ.get("DMI_API_URL", "https://dmigw.govcloud.dk/v2/metObs/collections/observation/items")
+DMI_API_KEY = os.environ.get("DMI_API_KEY")
+
+
+def _ensure_cache_dir() -> None:
+    os.makedirs(DMI_CACHE_DIR, exist_ok=True)
+
+
+def _cache_file_path(date: datetime) -> str:
+    return os.path.join(DMI_CACHE_DIR, f"{date.strftime('%Y-%m-%d')}.json")
+
+
+def _is_day_cached(date: datetime) -> bool:
+    return os.path.exists(_cache_file_path(date))
+
+
+def _fetch_dmi_day(date: datetime) -> Optional[dict]:
+    params = {
+        "datetime": date.strftime("%Y-%m-%dT00:00:00Z"),
+        "api-key": DMI_API_KEY,
+    }
+    try:
+        print(f"Fetching weather data for {date.date()} from DMI")
+        resp = requests.get(DMI_API_URL, params=params, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        print(f"Failed fetching DMI data for {date.date()}")
+        return None
+
+
+def _save_day_cache(date: datetime, data: dict) -> None:
+    path = _cache_file_path(date)
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+def update_dmi_cache() -> None:
+    """Ensure cache exists from DMI_START_CACHE_DATE to today."""
+    if not DMI_START_CACHE_DATE:
+        return
+
+    _ensure_cache_dir()
+
+    start_date = datetime.fromisoformat(DMI_START_CACHE_DATE).date()
+    end_date = datetime.utcnow().date()
+    current = start_date
+    while current <= end_date:
+        if not _is_day_cached(current):
+            data = _fetch_dmi_day(current)
+            if data is not None:
+                print(f"Caching DMI data for {current}")
+                _save_day_cache(current, data)
+        current += timedelta(days=1)
+
+
+def _worker() -> None:
+    while True:
+        print("Running DMI cache update")
+        update_dmi_cache()
+        time.sleep(3600)
+
+
+def start_dmi_cache_worker() -> None:
+    if not DMI_START_CACHE_DATE:
+        return
+    thread = Thread(target=_worker, daemon=True)
+    thread.start()


### PR DESCRIPTION
## Summary
- create a DMI cache module that downloads missing DMI data from a start date
- hook worker into app startup
- document DMI cache environment variables
- add basic logging for cache updates

## Testing
- `python -m py_compile app.py functions.py dmi_cache.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684718a0304483249f38e8c49b6882fb