### PR TITLE
Add DMI cache date range support

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from functions import *
-from dmi_cache import start_dmi_cache_worker
+from dmi_cache import start_dmi_cache_worker, get_cached_date_range
 from datetime import datetime, timedelta
 import dash
 from dash import html, dcc, Input, Output, State
@@ -12,6 +12,14 @@ N_CLICKS = None
 
 df_mps = pd.DataFrame(columns=['Målepunkts ID', 'Info'])
 df_mp_data = None
+
+# Determine available weather data range from cache
+cached_range = get_cached_date_range()
+if cached_range:
+    pv_min_date, pv_max_date = cached_range
+else:
+    pv_min_date = datetime.utcnow().date() - timedelta(days=30)
+    pv_max_date = datetime.utcnow().date()
 
 # Initialize the app
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
@@ -138,8 +146,10 @@ app.layout = dbc.Container([
             html.H6("Periode for solcellevejr"),
             dcc.DatePickerRange(
                 id='pv-date-picker-range',
-                start_date=datetime.now()-timedelta(days=30),
-                end_date=datetime.now(),
+                start_date=pv_min_date,
+                end_date=pv_max_date,
+                min_date_allowed=pv_min_date,
+                max_date_allowed=pv_max_date,
                 display_format="YYYY-MM-DD"
             ),
             html.Br(),

--- a/dmi_cache.py
+++ b/dmi_cache.py
@@ -3,7 +3,7 @@ import json
 import time
 from datetime import datetime, timedelta
 from threading import Thread
-from typing import Optional
+from typing import Optional, Tuple
 
 import requests
 
@@ -77,3 +77,30 @@ def start_dmi_cache_worker() -> None:
         return
     thread = Thread(target=_worker, daemon=True)
     thread.start()
+
+
+def get_cached_date_range() -> Optional[Tuple[datetime.date, datetime.date]]:
+    """Return the minimum and maximum dates available in the cache.
+
+    Scans :data:`DMI_CACHE_DIR` for ``*.json`` files.  The file names are
+    expected to be in ``YYYY-MM-DD.json`` format.  If no valid cache files are
+    found, ``None`` is returned.
+    """
+
+    if not os.path.isdir(DMI_CACHE_DIR):
+        return None
+
+    dates = []
+    for name in os.listdir(DMI_CACHE_DIR):
+        if not name.endswith(".json"):
+            continue
+        try:
+            date = datetime.strptime(os.path.splitext(name)[0], "%Y-%m-%d").date()
+            dates.append(date)
+        except ValueError:
+            continue
+
+    if not dates:
+        return None
+
+    return min(dates), max(dates)


### PR DESCRIPTION
## Summary
- implement `get_cached_date_range` utility in `dmi_cache`
- use cached DMI date range when building the Dash layout
- expose date bounds in `pv-date-picker-range`

## Testing
- `python -m py_compile app.py dmi_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_68471d016bd88324b4f39cc6977e55a2